### PR TITLE
Develop

### DIFF
--- a/scripts/base.sh
+++ b/scripts/base.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-perl -p -i -e 's#http://us.archive.ubuntu.com/ubuntu#http://mirror.rackspace.com/ubuntu#gi' /etc/apt/sources.list
-
 # Update the box
 apt-get -y update >/dev/null
 apt-get -q -y -o \'DPkg::Options::=--force-confold\' dist-upgrade

--- a/scripts/custom.sh
+++ b/scripts/custom.sh
@@ -6,5 +6,8 @@ sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_c
 # install additional packages
 apt-get -y install puppet lsb-release facter rsync curl
 
+# LEAP people like this: see also #6898
+apt-get -y install unzip vim tmux ntpdate git rdoc
+
 # Set root pw
 echo 'root:vagrant' | chpasswd 

--- a/scripts/custom.sh
+++ b/scripts/custom.sh
@@ -4,8 +4,7 @@
 sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 
 # install additional packages
-# openssl is needed to set root pw later
-apt-get -y install puppet lsb-release facter rsync curl openssl
+apt-get -y install puppet lsb-release facter rsync curl
 
 # Set root pw
-usermod -p "$(echo vagrant | openssl passwd -1 -stdin)" root
+echo 'root:vagrant' | chpasswd 


### PR DESCRIPTION
Strange, i cannot comment inline atm.

There's https://github.com/leapcode/leap_cli/pull/17 which takes out ntpdate, so i think we shouldn't install it here (in fact, we should install ntp). And i ran into troubles having both ntpdate and ntp install. I'll check if beaker really needs in (in fact i haven't followed the testing with beaker feature for a while).
So please include `ntp` instead of `ntpdate`.

About installing packages, i want to have the build as fast as possible, thats why i used one `apt-get install` instead of multiple ones (i even stared puting packages in http/preseed.cfg). Those two instances in the pull req. are fine, i just wanted to let you know that we should not include more apt-get calls.
